### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @clemens-chr


### PR DESCRIPTION
remove codeowners file to avoid having auto pr requests. This is key to make things maintainable and prevent PRs from being unmergeable if @clemens-chr specifically does not approve them (which he might not be able to if he's busy, while someone else from the community migth approve the PR)

Crucially, @clemens-chr 's you would still have rights to not merge. Really just a way to prevent you from being auto-assigned every PR that comes on this repository